### PR TITLE
订阅 sentinel 的连接断开后需要执行重连

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/killme2008/carmine-sentinel"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [com.taoensso/carmine "2.14.0"]]
   :plugins [[codox "0.6.8"]]
   :warn-on-reflection true)

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -147,17 +147,15 @@
           (swap! sentinel-resolved-specs assoc-in [sg master-name]
                  {:master master-spec
                   :slaves slaves})
-          (if (master-role? master-spec)
-            (do
-              (notify-event-listeners {:event "get-master-addr-by-name"
-                                       :sentinel-group sg
-                                       :master-name master-name
-                                       :master master
-                                       :slaves slaves})
-              [master-spec slaves rs-specs])
-            (do (swap! sentinel-resolved-specs dissoc-in [sg master-name])
-              nil))))
+          (make-sure-master-role master-spec)
+          (notify-event-listeners {:event "get-master-addr-by-name"
+                                   :sentinel-group sg
+                                   :master-name master-name
+                                   :master master
+                                   :slaves slaves})
+          [master-spec slaves rs-specs]))
       (catch Exception e
+        (swap! sentinel-resolved-specs dissoc-in [sg master-name])
         (notify-event-listeners
          {:event "error"
           :sentinel-group sg

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -325,7 +325,7 @@
 (comment
   (set-sentinel-groups!
    {:group1
-    {:specs [{:host "127.0.0.1" :port 26379}]}})
+    {:specs [{:host "127.0.0.1" :port 5000} {:host "127.0.0.1" :port 5001} {:host "127.0.0.1" :port 5002}]}})
   (let [server1-conn {:pool {} :spec {} :sentinel-group :group1 :master-name "mymaster"}]
     (println
      (wcar server1-conn

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -1,7 +1,6 @@
 (ns carmine-sentinel.core
   (:require [taoensso.carmine :as car]
-            [taoensso.carmine.commands :as cmds]
-            [taoensso.carmine.locks :as locks])
+            [taoensso.carmine.commands :as cmds])
   (:import (java.io EOFException)))
 
 ;; {Sentinel group -> master-name -> spec}

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -157,7 +157,6 @@
           (println "Asdfasdf" master-spec)
           [master-spec slaves rs-specs]))
       (catch Exception e
-        (println "asdfasdf")
         (swap! sentinel-resolved-specs dissoc-in [sg master-name])
         (notify-event-listeners
          {:event "error"
@@ -340,12 +339,9 @@
 (comment
   (set-sentinel-groups!
    {:group1
-    {:specs [{:host "127.0.0.1" :port 26379}
-             ;{:host "127.0.0.1" :port 5001} {:host "127.0.0.1" :port 5002}
-             ]}})
+    {:specs [{:host "127.0.0.1" :port 5000} {:host "127.0.0.1" :port 5001} {:host "127.0.0.1" :port 5002}]}})
   (let [server1-conn {:pool {} :spec {} :sentinel-group :group1 :master-name "mymaster"}]
     (println
      (wcar server1-conn
            (car/set "a" 100)
-           (car/get "a"))))
-  )
+           (car/get "a")))))

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -154,7 +154,6 @@
                                    :master-name master-name
                                    :master master
                                    :slaves slaves})
-          (println "Asdfasdf" master-spec)
           [master-spec slaves rs-specs]))
       (catch Exception e
         (swap! sentinel-resolved-specs dissoc-in [sg master-name])
@@ -192,7 +191,6 @@
                             ;;adds server returned new sentinel specs to tail.
                             (remove (apply hash-set (:specs conn))
                                     rs-specs))))
-            (println "adsfasdf" ms sls rs-specs)
             (choose-spec master-name ms sls prefer-slave? slaves-balancer))
           ;;Try next sentinel
           (recur (next specs)


### PR DESCRIPTION
`car/subscribe` 执行后，如果与 sentinel 的连接断开，需要能再次重连，再次去 subscribe 这个 sentinel 不然在下一次 resolve master spec 之前，任何 master 切换事件都无法通知到当前 client。

还遇到一些可能存在的问题稍后写在 issue 里先记录一下，后续再看看怎么解决。

close #13