### PR TITLE
订阅 sentinel 与获取 master 地址分开

### DIFF
--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -315,6 +315,8 @@
 (defn remove-sentinel-group!
   "Remove a sentinel group configuration by name."
   [group-name]
+  (doseq [sentinel-spec (get-in @sentinel-groups [group-name :specs])]
+    (unsubscribe-switch-master! sentinel-spec))
   (vswap! sentinel-groups dissoc group-name))
 
 (defn remove-last-resolved-spec!


### PR DESCRIPTION
close #12
主要是解决这里提到的事情：#12，但本 PR 基于 #11 为了避免 #11 过大难以 Review 所以把这里单独拆分出一个 PR 来。

主要做的改动是在每次获取 master spec 前，先根据当前配置的 sentinel list 访问所有 sentinel 获取 monitor 目标 master 的 sentinel 完整列表，之后 subscribe 所有 sentinel。在获取 master spec 过程中，不再 subscribe sentinel，只是从 sentinel 上获取 master 和 slave 的地址。

等 #11 能确认合并后，我再将 #11 的内容合并到这个分支，去除 #11 的内容后再来进行 Review。