### PR TITLE
carmine-sentinel/wcar 有没有可能支持不经过 sentinel 直连 redis?

### DIFF
--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -283,12 +283,14 @@
    It will resolve master from sentinel first time,then cache the result in
    memory for reusing."
   [conn]
-  (update conn
-          :spec
-          merge
-          (get-sentinel-redis-spec (:sentinel-group conn)
-                                   (:master-name conn)
-                                   conn)))
+  (if (and (:sentinel-group conn) (:master-name conn))
+    (update conn
+            :spec
+            merge
+            (get-sentinel-redis-spec (:sentinel-group conn)
+                                     (:master-name conn)
+                                     conn))
+    conn))
 
 (defmacro wcar
   "It's the same as taoensso.carmine/wcar, but supports


### PR DESCRIPTION
有没有可能支持这样的使用方式：
```clojure
(def server-spec
  {:host       (env :redis-host "127.0.0.1")
   :port       (int-env :redis-port 6379)
   :timeout-ms (int-env :redis-timeout 2000)
   :db         (int-env :redis-db 2)
   :password   (not-empty (env :redis-password))})

(defmacro wcar* [& body]
  (car-sentinel/wcar {:pool           pool
                      :spec           server-spec
                      :sentinel-group (env :sentinel-group-config)
                      :master-name    (env :sentinel-master-name)}
    ~@body))

(wcar*
  (car/set "x" 1))
```
通过环境变量去提供 sentinel-group 和 master-name 的配置，如果提供的话，则走 sentinel 方式去连 redis。如果没有提供，则通过 server-spec 配置内的 host, port 直接去连 redis。如果 server-spec 内忘记提供 host, port 就报错，连不上 redis。

这样的好处是在本地调试时候，不用将完整的 sentinel 环境全部搭建起来，只用起一个单机的 redis 就行了，本地配置不提供 :sentinel-group-config 和 :sentinel-master-name 的配置。之后在线上环境提供这两个配置就能使用线上的 sentinel 集群提供高可用。