### PR TITLE
是否考虑处理 pubsub 时 redis 如果宕机可能导致 subscriber 永久阻塞问题

### DIFF
--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -74,7 +74,7 @@
     (dissoc m k)))
 
 (defmacro silently [& body]
-  `(try ~@body (catch Throwable _#)))
+  `(try ~@body (catch Exception _#)))
 
 (defn notify-event-listeners [event]
   (doseq [listener @event-listeners]

--- a/src/carmine_sentinel/core.clj
+++ b/src/carmine_sentinel/core.clj
@@ -113,7 +113,7 @@
               ;; support ping/pong test for a connection waiting for an event publishing
               ;; from redis, we do need this to maintain liveness in case redis server
               ;; crash unintentionally. Ref. https://github.com/antirez/redis/issues/420
-              (let [spec-with-timeout (update {:a 1 :B 2} :timeout-ms #(or % 10000))
+              (let [spec-with-timeout (update spec :timeout-ms #(or % 10000))
                     f (->> (car/with-new-pubsub-listener spec-with-timeout
                              {"+switch-master" (partial handle-switch-master sg)}
                              (car/subscribe "+switch-master"))


### PR DESCRIPTION
因为 Carmine 没有实现在 subscribe 状态的 Ping/Pong 所以在执行 subscribe 后 redis server 如果突然宕机，subscriber 可能会长时间处在阻塞状态等待 event，直到通过 tcp 自己的 keep alive 机制才能发现连接已经断开。有个参考的 issue：https://github.com/antirez/redis/issues/420